### PR TITLE
Add Star Citizen Wikis

### DIFF
--- a/WikiLookup.json
+++ b/WikiLookup.json
@@ -545,5 +545,25 @@
 			"Hyrule Warriors",
 			"Tingle"
 		]
+	},
+	{
+		"name": "Star Citizen Wiki",
+		"homepage": "https://starcitizen.tools",
+		"lang": "en",
+		"api": "https://starcitizen.tools/api.php",
+		"games": [
+			"Star Citizen",
+			"Squadron 42"
+		]
+	},
+	{
+		"name": "Star Citizen Wiki",
+		"homepage": "https://star-citizen.wiki/Star_Citizen_Wiki",
+		"lang": "de",
+		"api": "https://star-citizen.wiki/api.php",
+		"games": [
+			"Star Citizen",
+			"Squadron 42"
+		]
 	}
 ]

--- a/WikiLookup.json
+++ b/WikiLookup.json
@@ -565,5 +565,15 @@
 			"Star Citizen",
 			"Squadron 42"
 		]
+	},
+	{
+		"name": "星际公民中文Wiki",
+		"homepage": "https://sctoolszh.miraheze.org/wiki/%E9%A6%96%E9%A1%B5",
+		"lang": "zh",
+		"api": "https://sctoolszh.miraheze.org/w/api.php",
+		"games": [
+			"Star Citizen",
+			"Squadron 42"
+		]
 	}
 ]


### PR DESCRIPTION
- [x] Primary focus of the wiki must be computer or video games
- Games: _Star Citizen_, _Squadron 42_
- [x] Hosted on a site that doesn't cross-promote individual wikis across their network, unless they host fewer than 42 wikis.
- Both hosted independently and from each other
- [x] Continuously online
- Up time status: [English](https://status.starcitizen.tools/), [German](https://status.star-citizen.wiki/), Chinese wiki is on Miraheze
- [x] Using the MediaWiki software

~~There is also a Chinese wiki but it is hosted on Miraheze, so I am not sure if it fits the requirements.~~ Added to the JSON file.