### PR TITLE
Add Paradox Interactive Wikis (1)

### DIFF
--- a/WikiLookup.json
+++ b/WikiLookup.json
@@ -783,9 +783,6 @@
 		"api": "https://eu4.paradoxwikis.com/api.php",
 		"games": [
 			"Europa Universalis IV"
-		],
-		"series": [
-			"Europa Universalis"
 		]
 	},
 	{
@@ -804,9 +801,6 @@
 		"api": "https://hoi4.paradoxwikis.com/api.php",
 		"games": [
 			"Hearts of Iron IV"
-		],
-		"series": [
-			"Hearts of Iron"
 		]
 	},
 	{
@@ -816,9 +810,6 @@
 		"api": "https://ck3.paradoxwikis.com/api.php",
 		"games": [
 			"Crusader Kings III"
-		],
-		"series": [
-			"Crusader Kings"
 		]
 	},
 	{
@@ -828,9 +819,6 @@
 		"api": "https://vic3.paradoxwikis.com/api.php",
 		"games": [
 			"Victoria 3"
-		],
-		"series": [
-			"Victoria"
 		]
 	},
 	{
@@ -840,9 +828,6 @@
 		"api": "https://aow4.paradoxwikis.com/api.php",
 		"games": [
 			"Age of Wonders 4"
-		],
-		"series": [
-			"Age of Wonders"
 		]
 	},
 	{
@@ -852,9 +837,6 @@
 		"api": "https://cs2.paradoxwikis.com/api.php",
 		"games": [
 			"Cities: Skylines II"
-		],
-		"series": [
-			"Cities: Skylines"
 		]
 	},
 	{
@@ -896,7 +878,6 @@
 			"Vampire: The Masquerade - Reckoning of New York"
 		],
 		"series": [
-			"World of Darkness",
 			"Vampire: The Masquerade"
 		]
 	},
@@ -909,7 +890,6 @@
 			"Hunter: The Reckoning - The Beast of Glenkildove"
 		],
 		"series": [
-			"World of Darkness",
 			"Hunter: The Reckoning"
 		]
 	},
@@ -925,7 +905,6 @@
 			"Werewolf: The Apocalypse - Purgatory"
 		],
 		"series": [
-			"World of Darkness",
 			"Werewolf: The Apocalypse"
 		]
 	},
@@ -945,9 +924,6 @@
 		"api": "https://sta.paradoxwikis.com/api.php",
 		"games": [
 			"Surviving The Aftermath"
-		],
-		"series": [
-			"Surviving"
 		]
 	},
 	{
@@ -957,9 +933,6 @@
 		"api": "https://survivingmars.paradoxwikis.com/api.php",
 		"games": [
 			"Surviving Mars"
-		],
-		"series": [
-			"Surviving"
 		]
 	},
 	{
@@ -978,9 +951,6 @@
 		"api": "https://ck2.paradoxwikis.com/api.php",
 		"games": [
 			"Crusader Kings II"
-		],
-		"series": [
-			"Crusader Kings"
 		]
 	},
 	{
@@ -989,9 +959,6 @@
 		"lang": "en",
 		"api": "https://skylines.paradoxwikis.com/api.php",
 		"games": [
-			"Cities: Skylines"
-		],
-		"series": [
 			"Cities: Skylines"
 		]
 	},
@@ -1002,9 +969,6 @@
 		"api": "https://aowplanetfall.paradoxwikis.com/api.php",
 		"games": [
 			"Age of Wonders: Planetfall"
-		],
-		"series": [
-			"Age of Wonders"
 		]
 	},
 	{
@@ -1023,9 +987,6 @@
 		"api": "https://hoi3.paradoxwikis.com/api.php",
 		"games": [
 			"Hearts of Iron III"
-		],
-		"series": [
-			"Hearts of Iron"
 		]
 	},
 	{
@@ -1035,9 +996,6 @@
 		"api": "https://eurome.paradoxwikis.com/api.php",
 		"games": [
 			"Europa Universalis: Rome"
-		],
-		"series": [
-			"Europa Universalis"
 		]
 	},
 	{
@@ -1047,9 +1005,6 @@
 		"api": "https://vic2.paradoxwikis.com/api.php",
 		"games": [
 			"Victoria II"
-		],
-		"series": [
-			"Victoria"
 		]
 	},
 	{
@@ -1059,9 +1014,6 @@
 		"api": "https://eu3.paradoxwikis.com/api.php",
 		"games": [
 			"Europa Universalis III"
-		],
-		"series": [
-			"Europa Universalis"
 		]
 	},
 	{
@@ -1071,9 +1023,6 @@
 		"api": "https://aod.paradoxwikis.com/api.php",
 		"games": [
 			"Arsenal of Democracy"
-		],
-		"series": [
-			"Hearts of Iron"
 		]
 	},
 	{
@@ -1083,9 +1032,6 @@
 		"api": "https://vic1.paradoxwikis.com/api.php",
 		"games": [
 			"Victoria: An Empire Under the Sun"
-		],
-		"series": [
-			"Victoria"
 		]
 	},
 	{
@@ -1095,9 +1041,6 @@
 		"api": "https://eu2.paradoxwikis.com/api.php",
 		"games": [
 			"Europa Universalis II"
-		],
-		"series": [
-			"Europa Universalis"
 		]
 	},
 	{
@@ -1107,9 +1050,6 @@
 		"api": "https://hoi2.paradoxwikis.com/api.php",
 		"games": [
 			"Hearts of Iron II"
-		],
-		"series": [
-			"Hearts of Iron"
 		]
 	}
 ]

--- a/WikiLookup.json
+++ b/WikiLookup.json
@@ -766,5 +766,350 @@
 		"series": [
 			"Golden Sun"
 		]
+	},
+	{
+		"name": "Central Paradox Wikis",
+		"homepage": "https://central.paradoxwikis.com/Main_Page",
+		"lang": "en",
+		"api": "https://central.paradoxwikis.com/api.php",
+		"companies": [
+			"Paradox Interactive"
+		]
+	},
+	{
+		"name": "Europa Universalis 4 Wiki",
+		"homepage": "https://eu4.paradoxwikis.com/Europa_Universalis_4_Wiki",
+		"lang": "en",
+		"api": "https://eu4.paradoxwikis.com/api.php",
+		"games": [
+			"Europa Universalis IV"
+		],
+		"series": [
+			"Europa Universalis"
+		]
+	},
+	{
+		"name": "Stellaris Wiki",
+		"homepage": "https://stellaris.paradoxwikis.com/Stellaris_Wiki",
+		"lang": "en",
+		"api": "https://stellaris.paradoxwikis.com/api.php",
+		"games": [
+			"Stellaris"
+		]
+	},
+	{
+		"name": "Hearts of Iron 4 Wiki",
+		"homepage": "https://hoi4.paradoxwikis.com/Hearts_of_Iron_4_Wiki",
+		"lang": "en",
+		"api": "https://hoi4.paradoxwikis.com/api.php",
+		"games": [
+			"Hearts of Iron IV"
+		],
+		"series": [
+			"Hearts of Iron"
+		]
+	},
+	{
+		"name": "Crusader Kings III Wiki",
+		"homepage": "https://ck3.paradoxwikis.com/Crusader_Kings_III_Wiki",
+		"lang": "en",
+		"api": "https://ck3.paradoxwikis.com/api.php",
+		"games": [
+			"Crusader Kings III"
+		],
+		"series": [
+			"Crusader Kings"
+		]
+	},
+	{
+		"name": "Victoria 3 Wiki",
+		"homepage": "https://vic3.paradoxwikis.com/Victoria_3_Wiki",
+		"lang": "en",
+		"api": "https://vic3.paradoxwikis.com/api.php",
+		"games": [
+			"Victoria 3"
+		],
+		"series": [
+			"Victoria"
+		]
+	},
+	{
+		"name": "Age of Wonders 4 Wiki",
+		"homepage": "https://aow4.paradoxwikis.com/Age_of_Wonders_4_Wiki",
+		"lang": "en",
+		"api": "https://aow4.paradoxwikis.com/api.php",
+		"games": [
+			"Age of Wonders 4"
+		],
+		"series": [
+			"Age of Wonders"
+		]
+	},
+	{
+		"name": "Cities Skylines 2 Wiki",
+		"homepage": "https://cs2.paradoxwikis.com/Cities_Skylines_II_Wiki",
+		"lang": "en",
+		"api": "https://cs2.paradoxwikis.com/api.php",
+		"games": [
+			"Cities: Skylines II"
+		],
+		"series": [
+			"Cities: Skylines"
+		]
+	},
+	{
+		"name": "Millennia Wiki",
+		"homepage": "https://millennia.paradoxwikis.com/Millennia_Wiki",
+		"lang": "en",
+		"api": "https://millennia.paradoxwikis.com/api.php",
+		"games": [
+			"Millennia"
+		]
+	},
+	{
+		"name": "Prison Architect Wiki",
+		"homepage": "https://prisonarchitect.paradoxwikis.com/Main_Page",
+		"lang": "en",
+		"api": "https://prisonarchitect.paradoxwikis.com/api.php",
+		"games": [
+			"Prison Architect"
+		]
+	},
+	{
+		"name": "Vampire: The Masquerade Wiki",
+		"homepage": "https://vtm.paradoxwikis.com/VTM_Wiki",
+		"lang": "en",
+		"api": "https://vtm.paradoxwikis.com/api.php",
+		"games": [
+			"Vampire: The Masquerade - Justice",
+			"Vampire: The Masquerade - Heartless Lullaby",
+			"Vampire: The Masquerade - Bloodhunt",
+			"Vampire: The Masquerade - Swansong",
+			"Vampire: The Masquerade - Coteries of New York",
+			"Vampire: The Masquerade - Shadows of New York",
+			"Vampire: The Masquerade - Night Road",
+			"Vampire: The Masquerade - Out for Blood",
+			"Vampire: The Masquerade - Parliament of Knives",
+			"Vampire: The Masquerade - Sins of the Sires",
+			"Vampire: The Masquerade - Bloodlines 2",
+			"Vampire: The Masquerade - Clans of London",
+			"Vampire: The Masquerade - Reckoning of New York"
+		],
+		"series": [
+			"World of Darkness",
+			"Vampire: The Masquerade"
+		]
+	},
+	{
+		"name": "Hunter: The Reckoning Wiki",
+		"homepage": "https://htr.paradoxwikis.com/Hunter_The_Reckoning_Wiki",
+		"lang": "en",
+		"api": "https://htr.paradoxwikis.com/api.php",
+		"games": [
+			"Hunter: The Reckoning - The Beast of Glenkildove"
+		],
+		"series": [
+			"World of Darkness",
+			"Hunter: The Reckoning"
+		]
+	},
+	{
+		"name": "Werewolf: The Apocalypse Wiki",
+		"homepage": "https://wta.paradoxwikis.com/Werewolf_The_Apocalypse_Wiki",
+		"lang": "en",
+		"api": "https://wta.paradoxwikis.com/api.php",
+		"games": [
+			"Werewolf: The Apocalypse - The Book of Hungry Names",
+			"Werewolf: The Apocalypse - Heart of the Forest",
+			"Werewolf: The Apocalypse - Earthblood",
+			"Werewolf: The Apocalypse - Purgatory"
+		],
+		"series": [
+			"World of Darkness",
+			"Werewolf: The Apocalypse"
+		]
+	},
+	{
+		"name": "Imperator Wiki",
+		"homepage": "https://imperator.paradoxwikis.com/Imperator_Wiki",
+		"lang": "en",
+		"api": "https://imperator.paradoxwikis.com/api.php",
+		"games": [
+			"Imperator: Rome"
+		]
+	},
+	{
+		"name": "Surviving the Aftermath Wiki",
+		"homepage": "https://sta.paradoxwikis.com/Surviving_The_Aftermath_Wiki",
+		"lang": "en",
+		"api": "https://sta.paradoxwikis.com/api.php",
+		"games": [
+			"Surviving The Aftermath"
+		],
+		"series": [
+			"Surviving"
+		]
+	},
+	{
+		"name": "Surviving Mars Wiki",
+		"homepage": "https://survivingmars.paradoxwikis.com/Surviving_Mars_Wiki",
+		"lang": "en",
+		"api": "https://survivingmars.paradoxwikis.com/api.php",
+		"games": [
+			"Surviving Mars"
+		],
+		"series": [
+			"Surviving"
+		]
+	},
+	{
+		"name": "Empire of Sin Wiki",
+		"homepage": "https://eos.paradoxwikis.com/Empire_of_Sin_Wiki",
+		"lang": "en",
+		"api": "https://eos.paradoxwikis.com/api.php",
+		"games": [
+			"Empire of Sin"
+		]
+	},
+	{
+		"name": "Crusader Kings II Wiki",
+		"homepage": "https://ck2.paradoxwikis.com/Crusader_Kings_II_Wiki",
+		"lang": "en",
+		"api": "https://ck2.paradoxwikis.com/api.php",
+		"games": [
+			"Crusader Kings II"
+		],
+		"series": [
+			"Crusader Kings"
+		]
+	},
+	{
+		"name": "Cities: Skylines Wiki",
+		"homepage": "https://skylines.paradoxwikis.com/Cities:_Skylines_Wiki",
+		"lang": "en",
+		"api": "https://skylines.paradoxwikis.com/api.php",
+		"games": [
+			"Cities: Skylines"
+		],
+		"series": [
+			"Cities: Skylines"
+		]
+	},
+	{
+		"name": "AoW: Planetfall Wiki",
+		"homepage": "https://aowplanetfall.paradoxwikis.com/AoW_Planetfall_Wiki",
+		"lang": "en",
+		"api": "https://aowplanetfall.paradoxwikis.com/api.php",
+		"games": [
+			"Age of Wonders: Planetfall"
+		],
+		"series": [
+			"Age of Wonders"
+		]
+	},
+	{
+		"name": "Tyranny Wiki",
+		"homepage": "https://tyranny.paradoxwikis.com/Tyranny_Wiki",
+		"lang": "en",
+		"api": "https://tyranny.paradoxwikis.com/api.php",
+		"games": [
+			"Tyranny"
+		]
+	},
+	{
+		"name": "Hearts of Iron 3 Wiki",
+		"homepage": "https://hoi3.paradoxwikis.com/Hearts_of_Iron_3_Wiki",
+		"lang": "en",
+		"api": "https://hoi3.paradoxwikis.com/api.php",
+		"games": [
+			"Hearts of Iron III"
+		],
+		"series": [
+			"Hearts of Iron"
+		]
+	},
+	{
+		"name": "Europa Universalis: Rome Wiki",
+		"homepage": "https://eurome.paradoxwikis.com/Europa_Universalis:_Rome_Wiki",
+		"lang": "en",
+		"api": "https://eurome.paradoxwikis.com/api.php",
+		"games": [
+			"Europa Universalis: Rome"
+		],
+		"series": [
+			"Europa Universalis"
+		]
+	},
+	{
+		"name": "Victoria 2 Wiki",
+		"homepage": "https://vic2.paradoxwikis.com/Victoria_2_Wiki",
+		"lang": "en",
+		"api": "https://vic2.paradoxwikis.com/api.php",
+		"games": [
+			"Victoria II"
+		],
+		"series": [
+			"Victoria"
+		]
+	},
+	{
+		"name": "Europa Universalis 3 Wiki",
+		"homepage": "https://eu3.paradoxwikis.com/Europa_Universalis_3_Wiki",
+		"lang": "en",
+		"api": "https://eu3.paradoxwikis.com/api.php",
+		"games": [
+			"Europa Universalis III"
+		],
+		"series": [
+			"Europa Universalis"
+		]
+	},
+	{
+		"name": "Arsenal of Democracy Wiki",
+		"homepage": "https://aod.paradoxwikis.com/Main_Page",
+		"lang": "en",
+		"api": "https://aod.paradoxwikis.com/api.php",
+		"games": [
+			"Arsenal of Democracy"
+		],
+		"series": [
+			"Hearts of Iron"
+		]
+	},
+	{
+		"name": "Victoria 1 Wiki",
+		"homepage": "https://vic1.paradoxwikis.com/Main_Page",
+		"lang": "en",
+		"api": "https://vic1.paradoxwikis.com/api.php",
+		"games": [
+			"Victoria: An Empire Under the Sun"
+		],
+		"series": [
+			"Victoria"
+		]
+	},
+	{
+		"name": "Europa Universalis 2 Wiki",
+		"homepage": "https://eu2.paradoxwikis.com/Main_Page",
+		"lang": "en",
+		"api": "https://eu2.paradoxwikis.com/api.php",
+		"games": [
+			"Europa Universalis II"
+		],
+		"series": [
+			"Europa Universalis"
+		]
+	},
+	{
+		"name": "Hearts of Iron 2 Wiki",
+		"homepage": "https://hoi2.paradoxwikis.com/Main_Page",
+		"lang": "en",
+		"api": "https://hoi2.paradoxwikis.com/api.php",
+		"games": [
+			"Hearts of Iron II"
+		],
+		"series": [
+			"Hearts of Iron"
+		]
 	}
 ]


### PR DESCRIPTION
Submitted pull request following talk with Prod via ABXY's Discord server
All the wikis can be found on this page: https://wikis.paradoxplaza.com except for _Central Paradox Wikis_, which is found on https://central.paradoxwikis.com